### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
   pipelineTriggers([[$class:"SCMTrigger", scmpoll_spec:"H/10 * * * *"]]),
 ])
 
-node('docker') {
+node('docker&&linux') {
     def imageTag
     stage('Checkout') {
         deleteDir()


### PR DESCRIPTION
When Windows docker agents are available, make sure this only runs on Linux docker agents.